### PR TITLE
netvfy-agent hotfix

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -43,10 +43,10 @@ main(int argc, char *argv[])
 	int		 ch;
 	int		 list_networks = 0;
 	int		 del_network = 0;
+	int		 version = 0;
 	char		*provcode = NULL;
 	char		*network_name = NULL;
 	char		 new_name[64];
-	int		version; 
 
 	while ((ch = getopt(argc, argv, "hk:n:lc:d:v")) != -1) {
 


### PR DESCRIPTION
-c and -l now aren't broken by the addition of the -v (version) command: 
<img width="404" alt="Screen Shot 2019-07-17 at 8 22 26 AM" src="https://user-images.githubusercontent.com/913035/61375125-1728e080-a86c-11e9-96fc-5757ce797a1b.png">
<img width="388" alt="Screen Shot 2019-07-17 at 8 22 33 AM" src="https://user-images.githubusercontent.com/913035/61375126-1728e080-a86c-11e9-8f2a-70a0ecb6402b.png">
