### PR TITLE
switch to using netinfos array for reading netinfos from api endpoint

### DIFF
--- a/src/control.c
+++ b/src/control.c
@@ -700,7 +700,7 @@ peer_read_cb(struct bufferevent *bev, void *arg)
 		}
 
 		if (strcmp(action, "netinfos") == 0) {
-			if (json_unpack(jmsg, "{s:s, s:s, s:s}",
+			if (json_unpack(jmsg, "[{s:s, s:s, s:s}]",
 			    "addr", &vswitch_addr,
 			    "port", &vswitch_port,
 			    "ipaddr", &ipaddr) < 0) {


### PR DESCRIPTION
as per the documentation:
https://jansson.readthedocs.io/en/2.8/apiref.html
```
/* Build the JSON array [[1, 2], {"cool": true}] */
json_pack("[[i,i],{s:b}]", 1, 2, "cool", 1);
```