### PR TITLE
disable gui resizing

### DIFF
--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -4,7 +4,7 @@
 #include "../agent.h"
 
 MyFrame::MyFrame(wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style):
-    wxFrame(parent, id, title, pos, size, wxDEFAULT_FRAME_STYLE)
+    wxFrame(parent, id, title, pos, size, wxNETVFYDEFAULT)
 {
 	const int ID_CONNECT = 1;
 	const int ID_DISCONNECT = 2;

--- a/src/gui/maindialog.h
+++ b/src/gui/maindialog.h
@@ -7,6 +7,8 @@
 #include <wx/notebook.h>
 #include <wx/statline.h>
 
+#define wxNETVFYDEFAULT (wxSYSTEM_MENU | wxCLOSE_BOX | wxCAPTION | wxCLIP_CHILDREN)
+
 class MyFrame: public wxFrame {
 public:
 	MyFrame(wxWindow *parent, wxWindowID id, const wxString &title,


### PR DESCRIPTION
Note: I checked and realized that the default frame properties allowed for resizing and sizing buttons: 
```
#define wxDEFAULT_FRAME_STYLE (wxSYSTEM_MENU |          \
                               wxRESIZE_BORDER |        \
                               wxMINIMIZE_BOX |         \
                               wxMAXIMIZE_BOX |         \
                               wxCLOSE_BOX |            \
                               wxCAPTION |              \
                               wxCLIP_CHILDREN)
```
So I created a new definition of netvfydefaults which didn't include these constants.