### PR TITLE
give interface a nice name from the netname

### DIFF
--- a/src/control.c
+++ b/src/control.c
@@ -776,6 +776,8 @@ void tapcfg_log(int level, char *msg)
 	log_warnx("%s: %s", __func__, msg);
 }
 
+const char* strcat_copy(const char *str1, const char *str2);
+
 int
 control_init(const char *network_name)
 {
@@ -809,13 +811,15 @@ control_init(const char *network_name)
 
 	tapcfg_set_log_callback(vlink->tapcfg, tapcfg_log);
 
-	if ((vlink->tapfd = tapcfg_start(vlink->tapcfg, "netvfy0", 1)) < 0) {
-		log_warnx("%s: tapcfg_start", __func__);
+	if ((vlink->netname = strdup(network_name)) == NULL) {
+		log_warn("%s: strdup", __func__);
 		goto error;
 	}
 
-	if ((vlink->netname = strdup(network_name)) == NULL) {
-		log_warn("%s: strdup", __func__);
+
+	const char* ifname = strcat_copy(vlink->netname, "0");
+	if ((vlink->tapfd = tapcfg_start(vlink->tapcfg, ifname, 1)) < 0) {
+		log_warnx("%s: tapcfg_start", __func__);
 		goto error;
 	}
 
@@ -851,4 +855,23 @@ void
 control_fini(void)
 {
 	vlink_free(vlink);
+}
+
+const char* strcat_copy(const char *str1, const char *str2) {
+	int str1_len, str2_len;
+	char *new_str;
+
+	/* null check */
+
+	str1_len = strlen(str1);
+	str2_len = strlen(str2);
+
+	new_str = malloc(str1_len + str2_len + 1);
+
+	/* null check */
+
+	memcpy(new_str, str1, str1_len);
+	memcpy(new_str + str1_len, str2, str2_len + 1);
+
+	return new_str;
 }


### PR DESCRIPTION
if tapcfg does not support the name for length or special chars
it will fallback to tap0, tap1, etc.

I thought of reusing vlink->netname but I needed const char*

Solves #34 

```
22: ipv6test0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UNKNOWN group default qlen 1000
    inet 198.18.0.4/24 brd 198.18.0.255 scope global ipv6test0
       valid_lft forever preferred_lft forever
23: 2ndnet0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UNKNOWN group default qlen 1000
    inet 198.18.0.3/24 brd 198.18.0.255 scope global 2ndnet0
       valid_lft forever preferred_lft forever
```